### PR TITLE
allow longer formulas

### DIFF
--- a/Ranger.cxx
+++ b/Ranger.cxx
@@ -8,6 +8,7 @@ Ranger::Ranger(const TString& rootfile)
 {
     distr = std::uniform_int_distribution<std::mt19937::result_type>(0, ULONG_MAX);
     TTree::SetMaxTreeSize(1000000000000);
+    ROOT::v5::TFormula::SetMaxima(5000);
     setInputFile(input_filename);
 }
 

--- a/Ranger.h
+++ b/Ranger.h
@@ -18,6 +18,7 @@
 
 #include "TString.h"
 #include "TFormula.h"
+#include "v5/TFormula.h"
 #include "TFile.h"
 #include "TTree.h"
 #include "TLeaf.h"


### PR DESCRIPTION
I used the fix from https://root-forum.cern.ch/t/error-in-ttreeformula-compile-too-many-operators/8034 to allow longer TFormulas